### PR TITLE
Modify namespace to use generic arithmetic ops

### DIFF
--- a/src/scmtest/core.cljs
+++ b/src/scmtest/core.cljs
@@ -1,7 +1,8 @@
 (ns scmtest.core
+  (:refer-clojure :exclude [+ * / -])
   (:require [sicmutils.value :as vl]
             [sicmutils.numsymb :as ny]
-            [sicmutils.generic :as gn]
+            [sicmutils.generic :as gn :refer [+ * / -]]
             [sicmutils.ratio :as rt]
             [sicmutils.structure :as st]
             [sicmutils.simplify :as sp]


### PR DESCRIPTION
Hey @kloimhardt , I think this should fix the issue! The original code was using the core arithmetic operators; do differentiate you need the generic versions.

Let me know.